### PR TITLE
feet_exit, create & fix struct syscall_func

### DIFF
--- a/include/lib/user/syscall.h
+++ b/include/lib/user/syscall.h
@@ -5,6 +5,7 @@
 #include <debug.h>
 #include <stddef.h>
 
+
 /* Process identifier. */
 typedef int pid_t;
 #define PID_ERROR ((pid_t) -1)

--- a/include/threads/thread.h
+++ b/include/threads/thread.h
@@ -7,6 +7,7 @@
 #include "threads/interrupt.h"
 //lock 구조체를 모르니까 선언해줘야 합니다 -bs-
 #include "include/threads/synch.h"
+#include "filesys/file.h"
 #ifdef VM
 #include "vm/vm.h"
 #endif
@@ -102,6 +103,9 @@ struct thread
 	struct list donations;			//* 1주차 수정 (priority-donation): 이 쓰레드에게 우선순위를 기부한 쓰레드들의 리스트
 	struct list_elem donation_elem; //* 1주차 수정 (priority-donation) : donation list를 사용하기 위한 list_elem
 
+	int fd;							//* 2주차 쓰레드가 직접 연 파일의 식별자 저장
+	struct file *file;				//* 2주차 쓰레드가 직접 연 파일의 포인터
+	int exit_code;					//* 쓰레드가 종료할떄 상태인 exit_code
 	/* Shared between thread.c and synch.c. */
 	struct list_elem elem; /* List element. */
 

--- a/include/threads/thread.h
+++ b/include/threads/thread.h
@@ -105,7 +105,8 @@ struct thread
 
 	int fd;							//* 2주차 쓰레드가 직접 연 파일의 식별자 저장
 	struct file *file;				//* 2주차 쓰레드가 직접 연 파일의 포인터
-	int exit_code;					//* 쓰레드가 종료할떄 상태인 exit_code
+	short exit_code;					//* 쓰레드가 종료할떄 상태인 exit_code
+
 	/* Shared between thread.c and synch.c. */
 	struct list_elem elem; /* List element. */
 

--- a/include/userprog/syscall.h
+++ b/include/userprog/syscall.h
@@ -4,21 +4,51 @@
 #include <stdbool.h>
 #include <stdio.h>
 #include <syscall-nr.h>
+#include "include/threads/interrupt.h"
 
-struct values{
-    uint64_t syscall_number;
-    uint64_t rdi, rsi, rdx ,r10, r8, r9;
-};
+typedef int pid_t;
 
 struct syscall_func {
 	int syscall_number;
-	void (*function) (struct values *values);
+	void (*function) (struct intr_frame *f);
 };
-
 void syscall_init (void);
 
-void sysall_read();
-void syscall_write(struct values *values);
-void syscall_exit(struct values *values);
+// syscall function
+
+void syscall_halt(void);
+void syscall_exit(struct intr_frame *f);
+// fork func parameter : const char *thread_name
+pid_t syscall_fork (struct intr_frame *f);
+// exec func parameter : const char *cmd_line
+int syscall_exec (const char *cmd_line);
+// wait func parameter : pid_t pid
+int syscall_wait (pid_t pid);
+bool syscall_create (struct intr_frame *f);
+// remove func parameter : chonst char *file
+bool syscall_remove (struct intr_frame *f);
+// open func parameter : const char *file
+int syscall_open (struct intr_frame *f);
+// filesize func parameter : int fd
+int syscall_filesize (struct intr_frame *f);
+// read func parameter : int fd, void *buffer, unsigned size
+int syscall_read (struct intr_frame *f);
+// write func parameter : int fd, const void *buffer, unsigned size
+void syscall_write(struct intr_frame *f);
+// seek func parameter : int fd, unsigned position
+void syscall_seek (struct intr_frame *f);
+// tell func parameter : int fd
+unsigned syscall_tell (struct intr_frame *f);
+// close func larameter : int fd
+void syscall_close (struct intr_frame *f);
+
+// 공용 함수
+
+void syscall_abnormal_exit(short exit_code);
+// f의 값 출력 type 0 : d 출력, 1 : s 출력, 2 : 둘다 출력
+void print_values(struct intr_frame *f,int type);
+
+bool check_ptr_address(struct intr_frame *f);
+
 
 #endif /* userprog/syscall.h */

--- a/userprog/process.c
+++ b/userprog/process.c
@@ -329,7 +329,7 @@ process_exit (void) {
 	 * TODO: project2/process_termination.html).
 	 * TODO: We recommend you to implement process resource cleanup here. */
 	if(curr->pml4 > KERN_BASE)
-		printf ("%s: exit(%d)\n", curr->name,0);
+		printf ("%s: exit(%d)\n", curr->name,curr->exit_code);
 	process_cleanup ();
 }
 

--- a/userprog/syscall.c
+++ b/userprog/syscall.c
@@ -18,6 +18,8 @@
 #include "threads/flags.h"
 #include "intrinsic.h"
 
+#include "kernel/console.h"
+
 void syscall_entry (void);
 void syscall_handler (struct intr_frame *);
 
@@ -95,7 +97,9 @@ syscall_handler (struct intr_frame *f) {
 
 void syscall_write(struct values *values){
 	printf("%s",values->rsi);
+	
 }
 void syscall_exit(struct values *values){
+	thread_current()->exit_code = values->rdi;
 	thread_exit();
 }

--- a/userprog/syscall.c
+++ b/userprog/syscall.c
@@ -9,6 +9,7 @@
 */
 
 #include "userprog/syscall.h"
+
 #include <stdio.h>
 #include <syscall-nr.h>
 #include "threads/interrupt.h"
@@ -18,7 +19,8 @@
 #include "threads/flags.h"
 #include "intrinsic.h"
 
-#include "kernel/console.h"
+#include "filesys/filesys.h"
+#include "lib/user/syscall.h"
 
 void syscall_entry (void);
 void syscall_handler (struct intr_frame *);
@@ -53,53 +55,238 @@ syscall_init (void) {
 
 /* The main system call interface */
 
-void syscall_exit(struct values *values);
-void syscall_write(struct values *values);
+// syscall function
 
+void syscall_halt(void);
+void syscall_exit(struct intr_frame *f);
+// fork func parameter : const char *thread_name
+pid_t syscall_fork (struct intr_frame *f);
+// exec func parameter : const char *cmd_line
+int syscall_exec (const char *cmd_line);
+// wait func parameter : pid_t pid
+int syscall_wait (pid_t pid);
+bool syscall_create (struct intr_frame *f);
+// remove func parameter : chonst char *file
+bool syscall_remove (struct intr_frame *f);
+// open func parameter : const char *file
+int syscall_open (struct intr_frame *f);
+// filesize func parameter : int fd
+int syscall_filesize (struct intr_frame *f);
+// read func parameter : int fd, void *buffer, unsigned size
+int syscall_read (struct intr_frame *f);
+// write func parameter : int fd, const void *buffer, unsigned size
+void syscall_write(struct intr_frame *f);
+// seek func parameter : int fd, unsigned position
+void syscall_seek (struct intr_frame *f);
+// tell func parameter : int fd
+unsigned syscall_tell (struct intr_frame *f);
+// close func larameter : int fd
+void syscall_close (struct intr_frame *f);
+
+// 공용 함수
+
+void syscall_abnormal_exit(short exit_code);
+// f의 값 출력 type 0 : d 출력, 1 : s 출력, 2 : 둘다 출력
+void print_values(struct intr_frame *f,int type);
+
+bool check_ptr_address(struct intr_frame *f);
 
 struct syscall_func syscall_func[] = {
-	{SYS_HALT,syscall_exit},
+	{SYS_HALT,syscall_halt},
 	{SYS_EXIT,syscall_exit},
-	{SYS_FORK,syscall_exit},
-	{SYS_EXEC,syscall_exit},
-	{SYS_WAIT,syscall_exit},
-	{SYS_CREATE,syscall_exit},
-	{SYS_REMOVE,syscall_exit},
-	{SYS_OPEN,syscall_exit},
-	{SYS_FILESIZE,syscall_exit},
-	{SYS_READ,syscall_exit},
+	{SYS_FORK,syscall_fork},
+	{SYS_EXEC,syscall_exec},
+	{SYS_WAIT,syscall_wait},
+	{SYS_CREATE,syscall_create},
+	{SYS_REMOVE,syscall_remove},
+	{SYS_OPEN,syscall_open},
+	{SYS_FILESIZE,syscall_filesize},
+	{SYS_READ,syscall_read},
 	{SYS_WRITE,syscall_write},
-	{SYS_SEEK,syscall_exit},
-	{SYS_WRITE,syscall_exit},
-	{SYS_TELL,syscall_exit},
-	{SYS_CLOSE,syscall_exit},
+	{SYS_SEEK,syscall_seek},
+	{SYS_TELL,syscall_tell},
+	{SYS_CLOSE,syscall_close},
 };
+
 
 
 /* The main system call interface */
 void
 syscall_handler (struct intr_frame *f) {
-
 	// TODO: Your implementation goes here.
-	struct values values;
-	values.syscall_number = f->R.rax;
-	values.rdi = f->R.rdi;
-	values.rsi = f->R.rsi;
-	values.rdx = f->R.rdx;
-	values.r10 = f->R.r10;
-	values.r8 = f->R.r8;
-	values.r9 = f->R.r9;
 
-	struct syscall_func call = syscall_func[values.syscall_number];
-	call.function (&values);
+	// 전체 시스템 콜에 영향을 주는 곳입니다. 최대한 작성을 지양 해주세요
+
+	// print_values(f,0);
+
+	struct syscall_func call = syscall_func[f->R.rax];
+	call.function (f);
+
+	return;
+}
+
+// syscall function
+
+void syscall_halt(void){
+
+
+
 }
 
 
-void syscall_write(struct values *values){
-	printf("%s",values->rsi);
-	
-}
-void syscall_exit(struct values *values){
-	thread_current()->exit_code = values->rdi;
+void syscall_exit(struct intr_frame *f){
+
+	thread_current()->exit_code = f->R.rdi;
 	thread_exit();
+}
+
+
+// fork func parameter : const char *thread_name
+pid_t syscall_fork (struct intr_frame *f){
+
+
+	return NULL;
+}
+
+
+// exec func parameter : const char *cmd_line
+int syscall_exec (const char *cmd_line){
+
+
+	return 0;
+}
+
+
+// wait func parameter : pid_t pid
+int syscall_wait (pid_t pid){
+
+
+	return 0;
+}
+
+
+bool syscall_create (struct intr_frame *f){
+	bool success;
+
+	// if(!check_ptr_address(f)){
+	// 	syscall_abnormal_exit(-1);
+	// }
+	
+	if(f->R.rdi == 0){
+		syscall_abnormal_exit(-1);
+	}
+	success = filesys_create(f->R.rdi,f->R.rsi);
+	f->R.rax = success;
+	return success;
+}
+
+
+// remove func parameter : chonst char *file
+bool syscall_remove (struct intr_frame *f){
+
+
+	return 0;
+}
+
+
+// open func parameter : const char *file
+int syscall_open (struct intr_frame *f){
+
+
+	return 0;
+}
+
+
+// filesize func parameter : int fd
+int syscall_filesize (struct intr_frame *f){
+
+
+	return 0;
+}
+
+
+// read func parameter : int fd, void *buffer, unsigned size
+int syscall_read (struct intr_frame *f){
+
+
+	return 0;
+}
+
+
+// write func parameter : int fd, const void *buffer, unsigned size
+void syscall_write(struct intr_frame *f){
+	int fd = f->R.rdi;
+	char *buf = f->R.rsi;
+	int size = f->R.rdx;
+	if(fd == 1){
+		putbuf(buf,size);
+	}	
+}
+
+
+// seek func parameter : int fd, unsigned position
+void syscall_seek (struct intr_frame *f){
+
+
+
+}
+
+
+// tell func parameter : int fd
+unsigned syscall_tell (struct intr_frame *f){
+
+
+	return 0;
+}
+
+
+// close func larameter : int fd
+void syscall_close (struct intr_frame *f){
+
+
+
+}
+
+
+// 공용 함수
+
+void syscall_abnormal_exit(short exit_code){
+	thread_current()->exit_code = exit_code;
+	thread_exit();
+}
+
+// f의 값 출력 type 0 : d 출력, 1 : s 출력, 2 : 둘다 출력
+void print_values(struct intr_frame *f,int type){
+
+	printf("call_num   %d\n",f->R.rax);
+	printf("rdi        %d\n",f->R.rdi);
+	if(type == 0){
+		printf("rsi        %d\n",f->R.rsi);
+	}else if(type == 1){
+		if(f->R.rsi == 0){
+			printf("rsi        %s\n",f->R.rsi);
+		}else{
+			printf("rsi        %s",f->R.rsi);
+		}
+	}else if(type == 2){
+		printf("rsi        %d\n",f->R.rsi);
+		if(f->R.rsi == 0){
+			printf("rsi        %s\n",f->R.rsi);
+		}else{
+			printf("rsi        %s",f->R.rsi);
+		}
+	}
+	printf("rdx        %d\n",f->R.rdx);
+	printf("r10        %d\n",f->R.r10);
+	printf("r8         %d\n",f->R.r8);
+	printf("r9         %d\n",f->R.r9);
+}
+
+
+bool check_ptr_address(struct intr_frame *f){
+	bool success = false;
+	if (f->rsp < f->R.rdi && f->rsp + (1<<12) <f->R.rdi){
+		success = true;
+	}
+	return success;
 }


### PR DESCRIPTION
# exit pass

- 간단한 방법으로 구현해뒀습니다. thread 구조체에 exit_code 를 따로 넣어서 exit 호출을 받으면 구조체 안에 코드를 가지고 있다가 죽기 전에 코드를 사용합니다.
- 함수에 인자로 전달해줘도 되는데 그러면 고칠 부분이 많아서 새로운 멤버를 넣어서 해결했습니다.
- 프린트 문을 exit 안에 넣는 것도 좋은 방법인거 같은데, 일단 TODO 가 있는 곳에서 코드를 작성했습니다. ( 없는 곳에 하면 멤버를 새로 안받아도 되기때문에 메모리가 아껴질수 있지만, 혹시 몰라서...

## exit pass
![image](https://user-images.githubusercontent.com/47360438/203077861-54eb8fba-bf4d-478f-a84a-8bd631b5c422.png)

## total 75 of 95 tests failed
![image](https://user-images.githubusercontent.com/47360438/203079252-08d0688a-ade6-41a5-a312-bb1e9c3946b5.png)

# feet create

- 파일 생성 부분을 만들었습니다. 지금은 filesys가 구축되어 있어서 쉽게 만들었지만 나중에 4주차를 위해서 한번씩 보시는걸 추천 드립니다.
- (정말 별거 없음... 가져다 쓴거라...)
- bad_ptr 문제에서 막혀서 못나가고 있습니다. 메모리 값 참조를 잘못된 곳에 하고 있는데, 기준을 모르겠습니다. 
- bss 경계선인거 같은데, 잘 모르겠습니다 ㅠㅠ

![image](https://user-images.githubusercontent.com/47360438/203166790-5102c81c-ce59-4cdd-8807-4c249aa4693d.png)

# 구조체 문제
#8 
구조체 문제 입니다.

# 프린트 함수

- syscall 함수 내에서 `intr_dump_frame (const struct intr_frame *f)` 가 출력이 잘안되고 있어서 하나 만들었습니다.
- print_values(intr 변수, 타입) 으로 호출하시면 됩니다.
- 타입은 0 1 2 가 있는데, rsi가 문자열로 올때가 있기 떄문에 찍기 쉽게 해뒀습니다.
- 타입 0은 10진수 1은 문자열 2는 둘다 출력입니다

<img width="532" alt="image" src="https://user-images.githubusercontent.com/47360438/203167933-6a83f883-7752-4ab4-9a07-e130fe18f676.png">

# 스켈레톤 코드

- 기본적인 스켈레톤 코드 짜서 넣어뒀습니다. 헤더파일에도 다 넣어 뒀기 떄문에 그냥 작성해둔곳에 맡으신 함수 작성하시면 됩니다.
- 원래 변수들을 intr_frame으로 받기 떄문에 필요한 함수들은 위에 주석으로 작성해 두었습니다. 보통 들어오는 순서와 같기 떄문에 rax, rdi, rsi, rdx, r10, r8, r9 순으로 담길겁니다.

https://github.com/yoojinLiz/pintos-kaist/blob/4e9e14322866e4766ae4960d155a298034a167f1/lib/user/syscall.c#L17-L29
