### PR TITLE
user memory access 함수 /syscall_remove 추가 - 병수 bad ptr 문제 해결

### DIFF
--- a/include/userprog/syscall.h
+++ b/include/userprog/syscall.h
@@ -50,5 +50,6 @@ void print_values(struct intr_frame *f,int type);
 
 bool check_ptr_address(struct intr_frame *f);
 
+void check_addr(void * addr); // 할당받는 유저 메모리 영역인지 확인 후, 아니라면 exit(-1)을 실행하는 함수입니다. (유진 추가)
 
 #endif /* userprog/syscall.h */

--- a/userprog/process.c
+++ b/userprog/process.c
@@ -52,6 +52,7 @@ process_create_initd (const char *file_name) {
 	//* 기존에 file_name을 인수로 받는 부분들을 file_name 대신 parsed_file_name을 받도록 수정한다.
 	char *fn_copy;
     char *save_ptr;
+    char *not_used;
 	tid_t tid;
 	
 	/* Make a copy of FILE_NAME. Otherwise there's a race between the caller and load(). 
@@ -61,11 +62,9 @@ process_create_initd (const char *file_name) {
 		return TID_ERROR;
 	strlcpy (fn_copy, file_name, PGSIZE); // filename을 fn_copy로 복사 
 
+	file_name = strtok_r(file_name," ",&not_used); // 이제 filename은 인자를 제외한 파일 명만 갖고 있는 상태, fn_copy는 파일명 + 인자를 가진 상태 
+
 	/* Create a new thread to execute FILE_NAME. */
-	
-	//*yj!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!! 고쳐줘
-	char * trash;
-	file_name = strtok_r(file_name," ",&trash);
 	tid = thread_create (file_name, PRI_DEFAULT, initd, fn_copy); 
 	// thread_create는 새로 생성하고 이를 block 시켜 ready_list에 넣어주고 선점 확인까지만 한다! 
 	// 이 쓰레드가 실행할 initd(fn_copy)는 process_init()로 프로세스를 초기화한 후, process_exec(f_name)로 프로세스를 실행한다. 

--- a/userprog/syscall.c
+++ b/userprog/syscall.c
@@ -128,14 +128,11 @@ syscall_handler (struct intr_frame *f) {
 // syscall function
 
 void syscall_halt(void){
-
-
-
+	power_off();	
 }
 
 
 void syscall_exit(struct intr_frame *f){
-
 	thread_current()->exit_code = f->R.rdi;
 	thread_exit();
 }

--- a/userprog/syscall.c
+++ b/userprog/syscall.c
@@ -171,7 +171,8 @@ bool syscall_create (struct intr_frame *f){
 	// if(!check_ptr_address(f)){
 	// 	syscall_abnormal_exit(-1);
 	// }
-	
+	check_addr(f->R.rdi); // 유진 추가 
+
 	if(f->R.rdi == 0){
 		syscall_abnormal_exit(-1);
 	}
@@ -282,7 +283,6 @@ void print_values(struct intr_frame *f,int type){
 	printf("r9         %d\n",f->R.r9);
 }
 
-
 bool check_ptr_address(struct intr_frame *f){
 	bool success = false;
 	if (f->rsp < f->R.rdi && f->rsp + (1<<12) <f->R.rdi){
@@ -290,3 +290,17 @@ bool check_ptr_address(struct intr_frame *f){
 	}
 	return success;
 }
+
+void check_addr(void * addr) {
+	struct thread *t = thread_current();
+	if(is_kernel_vaddr(addr) || pml4_get_page(t->pml4, addr)== NULL ){
+	/* pml4_get_page(t->pml4, addr) : pml4_get_page()는 두번째 인자로 들어온 유저 가상 주소와 대응하는 물리주소를 찾는다. 
+	   해당 물리 주소와 연결된 커널 가상 주소를 반환하거나 만약 해당 물리 주소가 가상 주소와 매핑되지 않은 영역이면 NULL을 반환한다.
+	   따라서 따라서 NULL인지 체크함으로서 포인터가 가리키는 주소가 유저 영역 내에 있지만 자신의 페이지로 할당하지 않은 영역인지 확인해야 한다 */
+	   syscall_abnormal_exit(-1); 
+	}
+}
+
+
+
+

--- a/userprog/syscall.c
+++ b/userprog/syscall.c
@@ -184,9 +184,12 @@ bool syscall_create (struct intr_frame *f){
 
 // remove func parameter : chonst char *file
 bool syscall_remove (struct intr_frame *f){
-
-
-	return 0;
+	bool success ; 
+	char* file = f->R.rdi ; // rdi : 파일 이름   
+	check_addr(file); 
+	success = filesys_remove(file);
+	f->R.rax = success; 
+	return success;
 }
 
 


### PR DESCRIPTION
# check_addr 함수 추가

과제 설명서에 보면 유저 메모리 엑세스 가능한 부분인지를 걸러야 하는 부분이 나와있었는데, 저희가 다 건너뛰었더라구요! 

주소가 접근 가능한 메모리 부분인지 확인하는 함수 check_addr 를 추가하였고, `bool syscall_create` 함수 내에 이 함수를 추가했더니 bad_ptr 케이스도 통과하네요! 

```c
void check_addr(void * addr) {
	struct thread *t = thread_current();
	if(is_kernel_vaddr(addr) || pml4_get_page(t->pml4, addr)== NULL ){
	/* pml4_get_page(t->pml4, addr) : pml4_get_page()는 두번째 인자로 들어온 유저 가상 주소와 대응하는 물리주소를 찾는다. 
	   해당 물리 주소와 연결된 커널 가상 주소를 반환하거나 만약 해당 물리 주소가 가상 주소와 매핑되지 않은 영역이면 NULL을 반환한다.
	   따라서 따라서 NULL인지 체크함으로서 포인터가 가리키는 주소가 유저 영역 내에 있지만 자신의 페이지로 할당하지 않은 영역인지 확인해야 한다 */
	   syscall_abnormal_exit(-1); 
	}
}
```
테스트 케이스는 51개 fail로 한개 더 줄어들었고, 근데 제꺼 보시다시피 Error2 가 뜨는데, 이게 왜 뜨는지 모르겠어서 이거 확인 되기 전에는 merge &pull 지'양' 해야 할거 같아요!!! 

![image](https://user-images.githubusercontent.com/95731504/203230120-4d3eb51b-5a04-412b-9dcf-1f132082b7bc.png)
