### PR TITLE
fork sema 추가

### DIFF
--- a/include/threads/thread.h
+++ b/include/threads/thread.h
@@ -111,6 +111,7 @@ struct thread
 	struct list children;			//* 2주차 수정 : 자식 프로세스(스레드)들을 담고있는 list
 	struct list_elem children_elem; //* 2주차 수정: 자식 list를 사용하기 위한 list_elem
 
+	struct semaphore *fork_sema ;    //* 2주차 수정: 자식 스레드가 do_fork를 진행하는 동안 인터럽트 금지
 	// *? 멀티 스레드가 아니므로 tid_t pid_t 동일?
 	// https://stackoverflow.com/questions/4517301/difference-between-pid-and-tid
 

--- a/threads/thread.c
+++ b/threads/thread.c
@@ -225,6 +225,7 @@ tid_t thread_create(const char *name, int priority,
 	/* Add to run queue. */
 	thread_unblock(t);
 	test_max_priority();
+	
 
 	return tid;
 }
@@ -462,7 +463,7 @@ init_thread(struct thread *t, const char *name, int priority)
 	list_init(&t->fd_list);
 
 	list_init(&t->children);
-	sema_init(&t->fork_sema, 0);
+	
 	
 
 }

--- a/threads/thread.c
+++ b/threads/thread.c
@@ -462,6 +462,7 @@ init_thread(struct thread *t, const char *name, int priority)
 	list_init(&t->fd_list);
 
 	list_init(&t->children);
+	sema_init(&t->fork_sema, 0);
 	
 
 }

--- a/userprog/process.c
+++ b/userprog/process.c
@@ -100,10 +100,11 @@ initd (void *f_name) {
 
 tid_t
 process_fork (const char *name, struct intr_frame *if_) {
-
+	
 // 	/* Clone current thread to new thread.*/
 	struct thread *parent = thread_current();
-
+	sema_init(&parent->fork_sema, 0);
+	
 	parent->tf = *if_;
 
 	// 포크 하기 전에 스택정보(_if)를 미리 복사 떠놓는 중. 포크로 생긴 자식에게 전해주려고 
@@ -118,7 +119,7 @@ process_fork (const char *name, struct intr_frame *if_) {
 	struct thread *child = get_child_process(pid);
 	// printf("child tid is %d \n",child->tid);
 
-	sema_down(&child->fork_sema); 
+	sema_down(&parent->fork_sema); 
 	printf("do_fork 완료 될 때까지 대기 중 =============================\n");
 	return pid;
 
@@ -255,17 +256,17 @@ __do_fork (void *aux) {
 	//*TODO file duplicate 사용해서 fd와 파일을 새로운 자식에게 입력해준다.
 	copy_fd_list(parent,current);
 
-	printf("테스트\n\n");
+	// printf("테스트\n\n");
 	process_init ();
 	/* Finally, switch to the newly created process. */
 	if (succ)
 		printf("excute\n");
-		sema_up(&current->fork_sema);
+		sema_up(&parent->fork_sema);
 		do_iret (&if_);
 		intr_set_level (old_level);
 error:
-	printf("에러 발생 시 프린트 \n");
-	sema_up(&current->fork_sema);
+	// printf("에러 발생 시 프린트 \n");
+	sema_up(&parent->fork_sema);
 	thread_exit ();
 	intr_set_level (old_level);
 }

--- a/userprog/syscall.c
+++ b/userprog/syscall.c
@@ -151,8 +151,6 @@ void syscall_exit(struct intr_frame *f){
 
 // fork func parameter : const char *thread_name
 pid_t syscall_fork (struct intr_frame *f){
-
-
 	char *file_name = f->R.rdi;
 	// print_values(f,1);
 	process_fork(file_name, f);

--- a/userprog/syscall.c
+++ b/userprog/syscall.c
@@ -182,7 +182,7 @@ int syscall_exec (struct intr_frame *f){
 		syscall_abnormal_exit(-1);
 	}
     return 0;
-
+}
 
 
 // wait func parameter : pid_t pid


### PR DESCRIPTION
# 1.구조체 및 초기화 
### 구조체 멤버변수 
`struct semaphore *fork_sema ;    //* 2주차 수정: 자식 스레드가 do_fork를 진행하는 동안 인터럽트 금지`

### 초기화 
process_fork에서 부모 스레드의 fork_sema를 0으로 초기화 합니다. `sema_init(&parent->fork_sema, 0);`

# 2. 사용
부모 스레드는 return 하기 전 sema_down을 통해서 sema_up을 기다리며 wait_list에 기다릴겁니다. 
do_fork 에서 자식 프로세스가 sema_up을 하면 그때 부모스레드가 다시 진행됩니다. 

# 테스트 결과  
![image](https://user-images.githubusercontent.com/95731504/203917796-db7912d2-c083-457e-bb25-ccd177aed2ce.png)
