### PR TITLE
유진 find_elem_match_fd_value 함수 내용 수정 및 이름 변경

### DIFF
--- a/include/threads/thread.h
+++ b/include/threads/thread.h
@@ -103,22 +103,21 @@ struct thread
 	struct list donations;			//* 1주차 수정 (priority-donation): 이 쓰레드에게 우선순위를 기부한 쓰레드들의 리스트
 	struct list_elem donation_elem; //* 1주차 수정 (priority-donation) : donation list를 사용하기 위한 list_elem
 
-
-	struct file *file;				//* 2주차 쓰레드가 직접 연 파일의 포인터
-	short exit_code;				//* 쓰레드가 종료할떄 상태인 exit_code
+	struct file *file; //* 2주차 쓰레드가 직접 연 파일의 포인터
+	short exit_code;   //* 쓰레드가 종료할떄 상태인 exit_code
 
 	tid_t parent_tid;				//* 2주차 수정 : 부모 프로레스(스레드)의 tid
-	tid_t children;			//* 2주차 수정 : 자식 프로세스(스레드)들을 담고있는 list
+	tid_t children;					//* 2주차 수정 : 자식 프로세스(스레드)들을 담고있는 list
 	struct list_elem children_elem; //* 2주차 수정: 자식 list를 사용하기 위한 list_elem
 	struct list_elem all_elem;
 
-	struct semaphore *fork_sema ;    //* 2주차 수정: 자식 스레드가 do_fork를 진행하는 동안 인터럽트 금지
+	struct semaphore *fork_sema; //* 2주차 수정: 자식 스레드가 do_fork를 진행하는 동안 인터럽트 금지
 
 	// *? 멀티 스레드가 아니므로 tid_t pid_t 동일?
 	// https://stackoverflow.com/questions/4517301/difference-between-pid-and-tid
-	
+
 	struct intr_frame parent_if; // _fork() 구현 때 사용, __do_fork() 함수
-	struct file* fd_table[10]; 
+	struct file *fd_table[10];
 
 	int fd_count;
 	struct list fd_list;

--- a/include/userprog/syscall.h
+++ b/include/userprog/syscall.h
@@ -53,7 +53,7 @@ void print_values(struct intr_frame *f,int type);
 bool check_ptr_address(struct intr_frame *f);
 
 void check_addr(void * addr); // 할당받는 유저 메모리 영역인지 확인 후, 아니라면 exit(-1)을 실행하는 함수입니다. (유진 추가)
-struct list_elem* find_elem_match_fd_value(int fd_value);
+struct fd * find_matched_fd(int fd_value);
 
 
 #endif /* userprog/syscall.h */

--- a/userprog/syscall.c
+++ b/userprog/syscall.c
@@ -285,17 +285,15 @@ int syscall_open (struct intr_frame *f){
 // filesize func parameter : int fd
 int syscall_filesize (struct intr_frame *f){
 	int fd_value = f->R.rdi;
-	struct fd *find_fd;
-	find_fd= find_matched_fd(fd_value);
+	struct fd *	find_fd= find_matched_fd(fd_value);
 	
 	if(find_fd == NULL){
 		f->R.rax = -1;
 		return -1;
 	}
-
-	struct inode * find_inode = file_get_inode(find_fd->file);
-	
-	int size = inode_length(find_inode);
+	int size = file_length (find_fd->file); //* file_length 함수에서 아래의 두 작업을 진행합니다!
+	// struct inode * find_inode = file_get_inode(find_fd->file);
+	// int size = inode_length(find_inode);
 	f->R.rax = size;
 	return size;
 }
@@ -488,7 +486,7 @@ find_matched_fd(int fd_value){
 	{
 		struct fd *find_fd = list_entry(cur, struct fd, elem);
 		if(find_fd->value == fd_value){
-			return list_entry(cur, struct fd, elem);
+			return find_fd;
 ;
 		}
 		cur = list_next(cur);

--- a/userprog/syscall.c
+++ b/userprog/syscall.c
@@ -473,29 +473,6 @@ void check_addr(void * addr) {
 	}
 }
 
-struct list_elem*
-find_elem_match_fd_value(int fd_value){ //! 이 함수를 수정해서 아래 find_matched_fd 를 만들었는데  추후 문제없으면 이로 대체할게요! 
-
-	struct list *fd_list = &thread_current()->fd_list;
-	struct list_elem * cur;
-
-	if(list_empty(fd_list)){
-		return NULL;
-	}
-
-	cur = list_begin(fd_list);
-	while (cur != list_end(fd_list))
-	{
-		struct fd *find_fd = list_entry(cur, struct fd, elem);
-		if(find_fd->value == fd_value){
-			return cur;
-		}
-		cur = list_next(cur);
-	}
-	return NULL;
-}
-
-
 struct fd *
 find_matched_fd(int fd_value){
 


### PR DESCRIPTION
## find_elem_match_fd_value() 함수 내용 변경 및 find_matched_fd() 로 이름 변경

기존의 `find_elem_match_fd_value` 함수는 현재 스레드의 fd_list에서 fd_value가 일치하는 list_elem을 찾아 이 주소를 리턴하고 있었는데, 실제로 이 함수를 호출하는 모든 함수들은 이 list_elem이 아닌, 이 list_elem에서 fd를 찾아서 이 fd를 사용하고 있더라구요! 

그래서 아예 함수 내에서 list_entry로 fd까지 찾아서 리턴하는 형태로 변경하고 이에 맞게 함수 이름을 수정했습니다. 관련한 헤더파일들까지 수정 완료 한 후 이 함수를 사용하는 모든 곳에서 새로운 함수를 적용했을 때 통과하는 테스트 갯수에 차이가 없다는 내용 확인했습니다! 

변경 전 함수와 변경 후 함수의 모습은 아래와 같습니다. 

1. 변경 전 
    
    ```c
    struct list_elem*
    find_elem_match_fd_value(int fd_value){ //! 이 함수를 수정해서 아래 find_matched_fd 를 만들었는데  추후 문제없으면 이로 대체할게요! 
    
    	struct list *fd_list = &thread_current()->fd_list;
    	struct list_elem * cur;
    
    	if(list_empty(fd_list)){
    		return NULL;
    	}
    
    	cur = list_begin(fd_list);
    	while (cur != list_end(fd_list))
    	{
    		struct fd *find_fd = list_entry(cur, struct fd, elem);
    		if(find_fd->value == fd_value){
    			return cur;
    		}
    		cur = list_next(cur);
    	}
    	return NULL;
    }
    ```
    

2. 변경 후 
    
    ```c
    struct fd *
    find_matched_fd(int fd_value){
    
    	struct list *fd_list = &thread_current()->fd_list;
    	struct list_elem * cur;
    
    	if(list_empty(fd_list)){
    		return NULL;
    	}
    
    	cur = list_begin(fd_list);
    	while (cur != list_end(fd_list))
    	{
    		struct fd *find_fd = list_entry(cur, struct fd, elem);
    		if(find_fd->value == fd_value){
    			return list_entry(cur, struct fd, elem);
    ;
    		}
    		cur = list_next(cur);
    	}
    	return NULL;
    }
    ```

테스트 케이스 갯수에 제한 없음 확인햇습니다! 
![image](https://user-images.githubusercontent.com/95731504/204127678-fca553e5-4d93-4f7e-94cb-9debe9e74116.png)
